### PR TITLE
Fix safari large screen responsiveness issue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -260,7 +260,7 @@ hr {
 @media screen and (min-width: 85em) {
   
   .cell-text {
-    font-size: .6vw;
+    font-size: .5vw;
   } 
 
   .grid {


### PR DESCRIPTION
## Description
Fixed bug in safari where while using larger screens, white space appeared under text in grid.

## Affected areas of application
Viewing main page in Safari.

## To-Dos
- [x] Create all files
- [x] Fill out HTML
- [x] Style with CSS
- [x] Make responsive
- [x] Include normalize.css
- [x] Write README
- [x] Deploy Github Pages Site
- [x] Test on browsers